### PR TITLE
The idea behind using free monads

### DIFF
--- a/random-fu/random-fu.cabal
+++ b/random-fu/random-fu.cabal
@@ -1,5 +1,5 @@
 name:                   random-fu
-version:                0.3.0.0
+version:                1.0.0.0
 stability:              provisional
 
 cabal-version:          >= 1.10

--- a/random-fu/src/Data/Random.hs
+++ b/random-fu/src/Data/Random.hs
@@ -50,8 +50,8 @@ module Data.Random
       -- * A few very common distributions
       Uniform(..), uniform, uniformT,
       StdUniform(..), stdUniform, stdUniformT,
-      -- Normal(..), normal, stdNormal, normalT, stdNormalT,
-      -- Gamma(..), gamma, gammaT,
+      Normal(..), normal, stdNormal, normalT, stdNormalT,
+      Gamma(..), gamma, gammaT,
 
       -- * Entropy Sources
       StatefulGen, RandomGen,
@@ -64,8 +64,8 @@ module Data.Random
 
 import Data.Random.Sample
 import Data.Random.Distribution
--- import Data.Random.Distribution.Gamma
--- import Data.Random.Distribution.Normal
+import Data.Random.Distribution.Gamma
+import Data.Random.Distribution.Normal
 import Data.Random.Distribution.Uniform
 
 import Data.Random.Lift ()

--- a/random-fu/src/Data/Random.hs
+++ b/random-fu/src/Data/Random.hs
@@ -50,8 +50,8 @@ module Data.Random
       -- * A few very common distributions
       Uniform(..), uniform, uniformT,
       StdUniform(..), stdUniform, stdUniformT,
-      Normal(..), normal, stdNormal, normalT, stdNormalT,
-      Gamma(..), gamma, gammaT,
+      -- Normal(..), normal, stdNormal, normalT, stdNormalT,
+      -- Gamma(..), gamma, gammaT,
 
       -- * Entropy Sources
       StatefulGen, RandomGen,
@@ -64,8 +64,8 @@ module Data.Random
 
 import Data.Random.Sample
 import Data.Random.Distribution
-import Data.Random.Distribution.Gamma
-import Data.Random.Distribution.Normal
+-- import Data.Random.Distribution.Gamma
+-- import Data.Random.Distribution.Normal
 import Data.Random.Distribution.Uniform
 
 import Data.Random.Lift ()

--- a/random-fu/src/Data/Random/Distribution.hs
+++ b/random-fu/src/Data/Random/Distribution.hs
@@ -57,7 +57,7 @@ class Distribution d t where
     -- |Return a random variable with the given distribution, pre-lifted to an arbitrary 'RVarT'.
     -- Any arbitrary 'RVar' can also be converted to an 'RVarT m' for an arbitrary 'm', using
     -- either 'lift' or 'sample'.
-    rvarT :: d t -> RVarT n t
+    rvarT :: Functor n => d t -> RVarT n t
     rvarT d = lift (rvar d)
 
 -- FIXME: I am not sure about giving default instances

--- a/random-fu/src/Data/Random/Distribution/Bernoulli.hs
+++ b/random-fu/src/Data/Random/Distribution/Bernoulli.hs
@@ -27,12 +27,12 @@ bernoulli p = rvar (Bernoulli p)
 -- |Generate a Bernoulli process with the given probability.  For @Bool@ results,
 -- @bernoulli p@ will return True (p*100)% of the time and False otherwise.
 -- For numerical types, True is replaced by 1 and False by 0.
-bernoulliT :: Distribution (Bernoulli b) a => b -> RVarT m a
+bernoulliT :: (Distribution (Bernoulli b) a, Functor m) => b -> RVarT m a
 bernoulliT p = rvarT (Bernoulli p)
 
 -- |A random variable whose value is 'True' the given fraction of the time
 -- and 'False' the rest.
-boolBernoulli :: (Fractional a, Ord a, Distribution StdUniform a) => a -> RVarT m Bool
+boolBernoulli :: (Fractional a, Ord a, Distribution StdUniform a, Functor m) => a -> RVarT m Bool
 boolBernoulli p = do
     x <- stdUniformT
     return (x <= p)
@@ -43,7 +43,7 @@ boolBernoulliCDF p False = (1 - realToFrac p)
 
 -- | @generalBernoulli t f p@ generates a random variable whose value is @t@
 -- with probability @p@ and @f@ with probability @1-p@.
-generalBernoulli :: Distribution (Bernoulli b) Bool => a -> a -> b -> RVarT m a
+generalBernoulli :: (Distribution (Bernoulli b) Bool, Functor m) => a -> a -> b -> RVarT m a
 generalBernoulli f t p = do
     x <- bernoulliT p
     return (if x then t else f)

--- a/random-fu/src/Data/Random/Distribution/Beta.hs
+++ b/random-fu/src/Data/Random/Distribution/Beta.hs
@@ -18,9 +18,9 @@ import Data.Random.Distribution.Uniform
 
 import Numeric.SpecFunctions
 
-{-# SPECIALIZE fractionalBeta :: Float  -> Float  -> RVarT m Float #-}
-{-# SPECIALIZE fractionalBeta :: Double -> Double -> RVarT m Double #-}
-fractionalBeta :: (Fractional a, Eq a, Distribution Gamma a, Distribution StdUniform a) => a -> a -> RVarT m a
+{-# SPECIALIZE fractionalBeta :: Functor m => Float  -> Float  -> RVarT m Float #-}
+{-# SPECIALIZE fractionalBeta :: Functor m => Double -> Double -> RVarT m Double #-}
+fractionalBeta :: (Fractional a, Eq a, Distribution Gamma a, Distribution StdUniform a, Functor m) => a -> a -> RVarT m a
 fractionalBeta 1 1 = stdUniformT
 fractionalBeta a b = do
     x <- gammaT a 1
@@ -32,9 +32,9 @@ fractionalBeta a b = do
 beta :: Distribution Beta a => a -> a -> RVar a
 beta a b = rvar (Beta a b)
 
-{-# SPECIALIZE betaT :: Float  -> Float  -> RVarT m Float #-}
-{-# SPECIALIZE betaT :: Double -> Double -> RVarT m Double #-}
-betaT :: Distribution Beta a => a -> a -> RVarT m a
+{-# SPECIALIZE betaT :: Functor m => Float  -> Float  -> RVarT m Float #-}
+{-# SPECIALIZE betaT :: Functor m => Double -> Double -> RVarT m Double #-}
+betaT :: (Distribution Beta a, Functor m) => a -> a -> RVarT m a
 betaT a b = rvarT (Beta a b)
 
 data Beta a = Beta a a

--- a/random-fu/src/Data/Random/Distribution/Binomial.hs
+++ b/random-fu/src/Data/Random/Distribution/Binomial.hs
@@ -25,10 +25,10 @@ import Numeric ( log1p )
     -- note that although it's fast enough for large (eg, 2^10000)
     -- @Integer@s, it's not accurate enough when using @Double@ as
     -- the @b@ parameter.
-integralBinomial :: (Integral a, Floating b, Ord b, Distribution Beta b, Distribution StdUniform b) => a -> b -> RVarT m a
+integralBinomial :: (Integral a, Floating b, Ord b, Distribution Beta b, Distribution StdUniform b, Functor m) => a -> b -> RVarT m a
 integralBinomial = bin 0
     where
-        bin :: (Integral a, Floating b, Ord b, Distribution Beta b, Distribution StdUniform b) => a -> a -> b -> RVarT m a
+        bin :: (Integral a, Floating b, Ord b, Distribution Beta b, Distribution StdUniform b, Functor m) => a -> a -> b -> RVarT m a
         bin !k !t !p
             | t > 10    = do
                 let a = 1 + t `div` 2
@@ -118,15 +118,15 @@ floatingBinomialLogPDF t p x = logPdf (Binomial (truncate t :: Integer) p) (floo
 binomial :: Distribution (Binomial b) a => a -> b -> RVar a
 binomial t p = rvar (Binomial t p)
 
-{-# SPECIALIZE binomialT :: Int     -> Float  -> RVarT m Int #-}
-{-# SPECIALIZE binomialT :: Int     -> Double -> RVarT m Int #-}
-{-# SPECIALIZE binomialT :: Integer -> Float  -> RVarT m Integer #-}
-{-# SPECIALIZE binomialT :: Integer -> Double -> RVarT m Integer #-}
-{-# SPECIALIZE binomialT :: Float   -> Float  -> RVarT m Float  #-}
-{-# SPECIALIZE binomialT :: Float   -> Double -> RVarT m Float  #-}
-{-# SPECIALIZE binomialT :: Double  -> Float  -> RVarT m Double #-}
-{-# SPECIALIZE binomialT :: Double  -> Double -> RVarT m Double #-}
-binomialT :: Distribution (Binomial b) a => a -> b -> RVarT m a
+{-# SPECIALIZE binomialT :: Functor m => Int     -> Float  -> RVarT m Int #-}
+{-# SPECIALIZE binomialT :: Functor m => Int     -> Double -> RVarT m Int #-}
+{-# SPECIALIZE binomialT :: Functor m => Integer -> Float  -> RVarT m Integer #-}
+{-# SPECIALIZE binomialT :: Functor m => Integer -> Double -> RVarT m Integer #-}
+{-# SPECIALIZE binomialT :: Functor m => Float   -> Float  -> RVarT m Float  #-}
+{-# SPECIALIZE binomialT :: Functor m => Float   -> Double -> RVarT m Float  #-}
+{-# SPECIALIZE binomialT :: Functor m => Double  -> Float  -> RVarT m Double #-}
+{-# SPECIALIZE binomialT :: Functor m => Double  -> Double -> RVarT m Double #-}
+binomialT :: (Distribution (Binomial b) a, Functor m) => a -> b -> RVarT m a
 binomialT t p = rvarT (Binomial t p)
 
 data Binomial b a = Binomial a b

--- a/random-fu/src/Data/Random/Distribution/Categorical.hs
+++ b/random-fu/src/Data/Random/Distribution/Categorical.hs
@@ -37,7 +37,7 @@ categorical = rvar . fromList
 
 -- |Construct a 'Categorical' random process from a list of probabilities
 -- and categories, where the probabilities all sum to 1.
-categoricalT :: (Num p, Distribution (Categorical p) a) => [(p,a)] -> RVarT m a
+categoricalT :: (Num p, Distribution (Categorical p) a, Functor m) => [(p,a)] -> RVarT m a
 categoricalT = rvarT . fromList
 
 -- |Construct a 'Categorical' random variable from a list of weights
@@ -47,7 +47,7 @@ weightedCategorical = rvar . fromWeightedList
 
 -- |Construct a 'Categorical' random process from a list of weights
 -- and categories. The weights do /not/ have to sum to 1.
-weightedCategoricalT :: (Fractional p, Eq p, Distribution (Categorical p) a) => [(p,a)] -> RVarT m a
+weightedCategoricalT :: (Fractional p, Eq p, Distribution (Categorical p) a, Functor m) => [(p,a)] -> RVarT m a
 weightedCategoricalT = rvarT . fromWeightedList
 
 -- | Construct a 'Categorical' distribution from a list of weighted categories.

--- a/random-fu/src/Data/Random/Distribution/ChiSquare.hs
+++ b/random-fu/src/Data/Random/Distribution/ChiSquare.hs
@@ -16,7 +16,7 @@ import Numeric.SpecFunctions
 chiSquare :: Distribution ChiSquare t => Integer -> RVar t
 chiSquare = rvar . ChiSquare
 
-chiSquareT :: Distribution ChiSquare t => Integer -> RVarT m t
+chiSquareT :: (Distribution ChiSquare t, Functor m) => Integer -> RVarT m t
 chiSquareT = rvarT . ChiSquare
 
 newtype ChiSquare b = ChiSquare Integer

--- a/random-fu/src/Data/Random/Distribution/Dirichlet.hs
+++ b/random-fu/src/Data/Random/Distribution/Dirichlet.hs
@@ -12,7 +12,7 @@ import Data.Random.Distribution.Gamma
 
 import Data.List
 
-fractionalDirichlet :: (Fractional a, Distribution Gamma a) => [a] -> RVarT m [a]
+fractionalDirichlet :: (Fractional a, Distribution Gamma a, Functor m) => [a] -> RVarT m [a]
 fractionalDirichlet []  = return []
 fractionalDirichlet [_] = return [1]
 fractionalDirichlet as = do
@@ -24,7 +24,7 @@ fractionalDirichlet as = do
 dirichlet :: Distribution Dirichlet [a] => [a] -> RVar [a]
 dirichlet as = rvar (Dirichlet as)
 
-dirichletT :: Distribution Dirichlet [a] => [a] -> RVarT m [a]
+dirichletT :: (Distribution Dirichlet [a], Functor m) => [a] -> RVarT m [a]
 dirichletT as = rvarT (Dirichlet as)
 
 newtype Dirichlet a = Dirichlet a deriving (Eq, Show)

--- a/random-fu/src/Data/Random/Distribution/Exponential.hs
+++ b/random-fu/src/Data/Random/Distribution/Exponential.hs
@@ -23,7 +23,7 @@ See also 'exponential'.
 -}
 newtype Exponential a = Exp a
 
-floatingExponential :: (Floating a, Distribution StdUniform a) => a -> RVarT m a
+floatingExponential :: (Floating a, Distribution StdUniform a, Functor m) => a -> RVarT m a
 floatingExponential lambdaRecip = do
     x <- stdUniformT
     return (negate (log x) * lambdaRecip)
@@ -48,7 +48,7 @@ A random variable transformer which samples from the exponential distribution.
 alternatively be viewed as an exponential random variable with parameter @lambda
 = 1 / mu@.
 -}
-exponentialT :: Distribution Exponential a => a -> RVarT m a
+exponentialT :: (Distribution Exponential a, Functor m) => a -> RVarT m a
 exponentialT = rvarT . Exp
 
 instance (Floating a, Distribution StdUniform a) => Distribution Exponential a where

--- a/random-fu/src/Data/Random/Distribution/Gamma.hs
+++ b/random-fu/src/Data/Random/Distribution/Gamma.hs
@@ -27,12 +27,12 @@ import Numeric.SpecFunctions
 
 -- |derived from  Marsaglia & Tang, "A Simple Method for generating gamma
 -- variables", ACM Transactions on Mathematical Software, Vol 26, No 3 (2000), p363-372.
-{-# SPECIALIZE mtGamma :: Double -> Double -> RVarT m Double #-}
-{-# SPECIALIZE mtGamma :: Float  -> Float  -> RVarT m Float  #-}
+{-# SPECIALIZE mtGamma :: Functor m => Double -> Double -> RVarT m Double #-}
+{-# SPECIALIZE mtGamma :: Functor m => Float  -> Float  -> RVarT m Float  #-}
 mtGamma
     :: (Floating a, Ord a,
         Distribution StdUniform a,
-        Distribution Normal a)
+        Distribution Normal a, Functor m)
     => a -> a -> RVarT m a
 mtGamma a b
     | a < 1     = do
@@ -64,13 +64,13 @@ mtGamma a b
 gamma :: (Distribution Gamma a) => a -> a -> RVar a
 gamma a b = rvar (Gamma a b)
 
-gammaT :: (Distribution Gamma a) => a -> a -> RVarT m a
+gammaT :: (Distribution Gamma a, Functor m) => a -> a -> RVarT m a
 gammaT a b = rvarT (Gamma a b)
 
 erlang :: (Distribution (Erlang a) b) => a -> RVar b
 erlang a = rvar (Erlang a)
 
-erlangT :: (Distribution (Erlang a) b) => a -> RVarT m b
+erlangT :: (Distribution (Erlang a) b, Functor m) => a -> RVarT m b
 erlangT a = rvarT (Erlang a)
 
 data    Gamma a    = Gamma a a

--- a/random-fu/src/Data/Random/Distribution/Multinomial.hs
+++ b/random-fu/src/Data/Random/Distribution/Multinomial.hs
@@ -8,7 +8,7 @@ import Data.Random.Distribution.Binomial
 multinomial :: Distribution (Multinomial p) [a] => [p] -> a -> RVar [a]
 multinomial ps n = rvar (Multinomial ps n)
 
-multinomialT :: Distribution (Multinomial p) [a] => [p] -> a -> RVarT m [a]
+multinomialT :: (Distribution (Multinomial p) [a], Functor m) => [p] -> a -> RVarT m [a]
 multinomialT ps n = rvarT (Multinomial ps n)
 
 data Multinomial p a where

--- a/random-fu/src/Data/Random/Distribution/Pareto.hs
+++ b/random-fu/src/Data/Random/Distribution/Pareto.hs
@@ -12,7 +12,7 @@ import Data.Random
 pareto :: Distribution Pareto a => a -> a -> RVar a
 pareto xM a = rvar (Pareto xM a)
 
-paretoT :: Distribution Pareto a => a -> a -> RVarT m a
+paretoT :: (Distribution Pareto a, Functor m) => a -> a -> RVarT m a
 paretoT xM a = rvarT (Pareto xM a)
 
 data Pareto a = Pareto !a !a

--- a/random-fu/src/Data/Random/Distribution/Poisson.hs
+++ b/random-fu/src/Data/Random/Distribution/Poisson.hs
@@ -19,10 +19,10 @@ import Data.Random.Distribution.Binomial
 import Control.Monad
 
 -- from Knuth, with interpretation help from gsl sources
-integralPoisson :: (Integral a, RealFloat b, Distribution StdUniform b, Distribution (Erlang a) b, Distribution (Binomial b) a) => b -> RVarT m a
+integralPoisson :: (Integral a, RealFloat b, Distribution StdUniform b, Distribution (Erlang a) b, Distribution (Binomial b) a, Functor m) => b -> RVarT m a
 integralPoisson = psn 0
     where
-        psn :: (Integral a, RealFloat b, Distribution StdUniform b, Distribution (Erlang a) b, Distribution (Binomial b) a) => a -> b -> RVarT m a
+        psn :: (Integral a, RealFloat b, Distribution StdUniform b, Distribution (Erlang a) b, Distribution (Binomial b) a, Functor m) => a -> b -> RVarT m a
         psn j mu
             | mu > 10   = do
                 let m = floor (mu * (7/8))
@@ -70,7 +70,7 @@ integralPoissonPDF mu k = exp (negate lambda) *
     k_fac_ln = foldl (+) 0 (map (log . fromIntegral) [1..k])
     lambda   = realToFrac mu
 
-fractionalPoisson :: (Num a, Distribution (Poisson b) Integer) => b -> RVarT m a
+fractionalPoisson :: (Num a, Distribution (Poisson b) Integer, Functor m) => b -> RVarT m a
 fractionalPoisson mu = liftM fromInteger (poissonT mu)
 
 fractionalPoissonCDF :: (CDF (Poisson b) Integer, RealFrac a) => b -> a -> Double
@@ -82,7 +82,7 @@ fractionalPoissonPDF mu k = pdf (Poisson mu) (floor k :: Integer)
 poisson :: (Distribution (Poisson b) a) => b -> RVar a
 poisson mu = rvar (Poisson mu)
 
-poissonT :: (Distribution (Poisson b) a) => b -> RVarT m a
+poissonT :: (Distribution (Poisson b) a, Functor m) => b -> RVarT m a
 poissonT mu = rvarT (Poisson mu)
 
 newtype Poisson b a = Poisson b

--- a/random-fu/src/Data/Random/Distribution/Rayleigh.hs
+++ b/random-fu/src/Data/Random/Distribution/Rayleigh.hs
@@ -12,7 +12,7 @@ import Data.Random.RVar
 import Data.Random.Distribution
 import Data.Random.Distribution.Uniform
 
-floatingRayleigh :: (Floating a, Eq a, Distribution StdUniform a) => a -> RVarT m a
+floatingRayleigh :: (Floating a, Eq a, Distribution StdUniform a, Functor m) => a -> RVarT m a
 floatingRayleigh s = do
     u <- stdUniformPosT
     return (s * sqrt (-2 * log u))
@@ -26,7 +26,7 @@ newtype Rayleigh a = Rayleigh a
 rayleigh :: Distribution Rayleigh a => a -> RVar a
 rayleigh = rvar . Rayleigh
 
-rayleighT :: Distribution Rayleigh a => a -> RVarT m a
+rayleighT :: (Distribution Rayleigh a, Functor m) => a -> RVarT m a
 rayleighT = rvarT . Rayleigh
 
 rayleighCDF :: Real a => a -> a -> Double

--- a/random-fu/src/Data/Random/Distribution/Simplex.hs
+++ b/random-fu/src/Data/Random/Distribution/Simplex.hs
@@ -35,7 +35,7 @@ instance (Ord a, Fractional a, Distribution StdUniform a) => Distribution StdSim
 stdSimplex :: Distribution StdSimplex [a] => Int -> RVar [a]
 stdSimplex k = rvar (StdSimplex k)
 
-stdSimplexT :: Distribution StdSimplex [a] => Int -> RVarT m [a]
+stdSimplexT :: (Distribution StdSimplex [a], Functor m) => Int -> RVarT m [a]
 stdSimplexT k = rvarT (StdSimplex k)
 
 -- |An algorithm proposed by Rubinstein & Melamed (1998).

--- a/random-fu/src/Data/Random/Distribution/StretchedExponential.hs
+++ b/random-fu/src/Data/Random/Distribution/StretchedExponential.hs
@@ -14,7 +14,7 @@ import Data.Random.Distribution.Uniform
 
 newtype StretchedExponential a = StretchedExp (a,a)
 
-floatingStretchedExponential :: (Floating a, Distribution StdUniform a) => a -> a -> RVarT m a
+floatingStretchedExponential :: (Floating a, Distribution StdUniform a, Functor m) => a -> a -> RVarT m a
 floatingStretchedExponential beta lambdaRecip = do
     x <- stdUniformT
     return (negate (log (1-x))**(1/beta) * lambdaRecip)
@@ -25,7 +25,7 @@ floatingStretchedExponentialCDF beta lambdaRecip x = 1 - exp (negate (realToFrac
 stretchedExponential :: Distribution StretchedExponential a => a -> a -> RVar a
 stretchedExponential beta lambdaRecip = rvar $ StretchedExp (beta, lambdaRecip)
 
-stretchedExponentialT :: Distribution StretchedExponential a => a -> a -> RVarT m a
+stretchedExponentialT :: (Distribution StretchedExponential a, Functor m) => a -> a -> RVarT m a
 stretchedExponentialT beta lambdaRecip = rvarT $ StretchedExp (beta, lambdaRecip)
 
 instance (Floating a, Distribution StdUniform a) => Distribution StretchedExponential a where

--- a/random-fu/src/Data/Random/Distribution/T.hs
+++ b/random-fu/src/Data/Random/Distribution/T.hs
@@ -24,7 +24,7 @@ import Numeric.SpecFunctions
 t :: Distribution T a => Integer -> RVar a
 t = rvar . T
 
-tT :: Distribution T a => Integer -> RVarT m a
+tT :: (Distribution T a, Functor m) => Integer -> RVarT m a
 tT = rvarT . T
 
 newtype T a = T Integer

--- a/random-fu/src/Data/Random/Distribution/Triangular.hs
+++ b/random-fu/src/Data/Random/Distribution/Triangular.hs
@@ -26,7 +26,7 @@ data Triangular a = Triangular {
     deriving (Eq, Show)
 
 -- |Compute a triangular distribution for a 'Floating' type.
-floatingTriangular :: (Floating a, Ord a, Distribution StdUniform a) => a -> a -> a -> RVarT m a
+floatingTriangular :: (Floating a, Ord a, Distribution StdUniform a, Functor m) => a -> a -> a -> RVarT m a
 floatingTriangular a b c
     | a > b     = floatingTriangular b a c
     | b > c     = floatingTriangular a c b

--- a/random-fu/src/Data/Random/Lift.hs
+++ b/random-fu/src/Data/Random/Lift.hs
@@ -39,7 +39,7 @@ instance Lift m m where
 instance Monad m => Lift T.Identity m where
     lift = return . T.runIdentity
 
-instance Lift (RVarT T.Identity) (RVarT m) where
+instance Functor m => Lift (RVarT T.Identity) (RVarT m) where
     lift x = runRVar x RGen
 
 -- | This instance is again incoherent with the others, but provides a

--- a/random-fu/src/Data/Random/Lift.hs
+++ b/random-fu/src/Data/Random/Lift.hs
@@ -48,21 +48,3 @@ instance Lift (RVarT T.Identity) (RVarT m) where
 instance T.MonadTrans t => Lift T.Identity (t T.Identity) where
     lift = T.lift
 
-#ifndef MTL2
-
--- | This instance is incoherent with the others. However,
--- by the law @lift (return x) == return x@, the results
--- must always be the same.
-instance Monad m => Lift MTL.Identity m where
-    lift = return . MTL.runIdentity
-
-instance Lift (RVarT MTL.Identity) (RVarT m) where
-    lift x = runRVarTWith (return . MTL.runIdentity) x RGen
-
--- | This instance is again incoherent with the others, but provides a
--- more-specific instance to resolve the overlap between the
--- @Lift m (t m)@ and @Lift Identity m@ instances.
-instance T.MonadTrans t => Lift MTL.Identity (t MTL.Identity) where
-    lift = T.lift
-
-#endif

--- a/random-fu/src/Data/Random/List.hs
+++ b/random-fu/src/Data/Random/List.hs
@@ -13,7 +13,7 @@ randomElement :: [a] -> RVar a
 randomElement = randomElementT
 
 
-randomElementT :: [a] -> RVarT m a
+randomElementT :: Functor m => [a] -> RVarT m a
 randomElementT [] = error "randomElementT: empty list!"
 randomElementT xs = do
     n <- uniformT 0 (length xs - 1)
@@ -24,7 +24,7 @@ randomElementT xs = do
 shuffle :: [a] -> RVar [a]
 shuffle = shuffleT
 
-shuffleT :: [a] -> RVarT m [a]
+shuffleT :: Functor m => [a] -> RVarT m [a]
 shuffleT [] = return []
 shuffleT xs = do
     is <- zipWithM (\_ i -> uniformT 0 i) (tail xs) [1..]
@@ -38,14 +38,14 @@ shuffleT xs = do
 shuffleN :: Int -> [a] -> RVar [a]
 shuffleN = shuffleNT
 
-shuffleNT :: Int -> [a] -> RVarT m [a]
+shuffleNT :: Functor m => Int -> [a] -> RVarT m [a]
 shuffleNT n xs = shuffleNofMT n n xs
 
 -- | A random variable that selects N arbitrary elements of a list of known length M.
 shuffleNofM :: Int -> Int -> [a] -> RVar [a]
 shuffleNofM = shuffleNofMT
 
-shuffleNofMT :: Int -> Int -> [a] -> RVarT m [a]
+shuffleNofMT :: Functor m => Int -> Int -> [a] -> RVarT m [a]
 shuffleNofMT 0 _ _ = return []
 shuffleNofMT n m xs
     | n > m     = error "shuffleNofMT: n > m"

--- a/rvar/rvar.cabal
+++ b/rvar/rvar.cabal
@@ -55,8 +55,10 @@ Library
 
   build-depends:        base            >= 3 && <5,
 
+  -- Begin for testing
                         vector,
                         mwc-random,
+  -- End for testing
 
                         bytestring,
                         free,

--- a/rvar/rvar.cabal
+++ b/rvar/rvar.cabal
@@ -54,6 +54,10 @@ Library
     build-depends:      mtl == 1.1.*
 
   build-depends:        base            >= 3 && <5,
+
+                        vector,
+                        mwc-random,
+
                         bytestring,
                         free,
                         MonadPrompt     == 1.0.*,

--- a/rvar/rvar.cabal
+++ b/rvar/rvar.cabal
@@ -55,6 +55,7 @@ Library
 
   build-depends:        base            >= 3 && <5,
                         bytestring,
+                        free,
                         MonadPrompt     == 1.0.*,
                         transformers    >= 0.2 && < 0.6,
                         random          >= 1.2.0

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -281,23 +281,22 @@ instance Functor n => MonadFree Prim (RVarT n) where
 
 data RGen = RGen
 
--- instance StatefulGen RGen (RVarT m) where
---     uniformWord8 RGen = RVarT $ liftF PrimWord8
---     {-# INLINE uniformWord8 #-}
---     uniformWord16 RGen = RVarT $ liftF PrimWord16
---     {-# INLINE uniformWord16 #-}
---     uniformWord32 RGen = RVarT $ liftF PrimWord32
---     {-# INLINE uniformWord32 #-}
---     uniformWord64 RGen = RVarT $ liftF PrimWord64
---     {-# INLINE uniformWord64 #-}
---     uniformShortByteString n RGen = RVarT $ liftF (PrimShortByteString n)
---     {-# INLINE uniformShortByteString #-}
+instance Functor m => StatefulGen RGen (RVarT m) where
+    uniformWord8 RGen = liftF PrimWord8
+    {-# INLINE uniformWord8 #-}
+    uniformWord16 RGen =liftF PrimWord16
+    {-# INLINE uniformWord16 #-}
+    uniformWord32 RGen =liftF PrimWord32
+    {-# INLINE uniformWord32 #-}
+    uniformWord64 RGen =liftF PrimWord64
+    {-# INLINE uniformWord64 #-}
+    uniformShortByteString n RGen = liftF (PrimShortByteString n)
+    {-# INLINE uniformShortByteString #-}
 
+uniformRVarT :: (Functor m, Uniform a) => RVarT m a
+uniformRVarT = uniformM RGen
+{-# INLINE uniformRVarT #-}
 
--- uniformRVarT :: Uniform a => RVarT m a
--- uniformRVarT = uniformM RGen
--- {-# INLINE uniformRVarT #-}
-
--- uniformRangeRVarT :: UniformRange a => (a, a) -> RVarT m a
--- uniformRangeRVarT r = uniformRM r RGen
--- {-# INLINE uniformRangeRVarT #-}
+uniformRangeRVarT :: (Functor m, UniformRange a) => (a, a) -> RVarT m a
+uniformRangeRVarT r = uniformRM r RGen
+{-# INLINE uniformRangeRVarT #-}

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -243,11 +243,11 @@ instance Applicative (RVarT n) where
 instance Functor n => MonadFree Prim (RVarT n) where
   wrap = RVarT . wrap . InL . fmap unRVarT
 
--- instance T.MonadTrans RVarT where
---     lift m = RVarT (MTL.lift m)
+instance T.MonadTrans RVarT where
+  lift = RVarT . wrap . InR . fmap unRVarT . fmap return
 
--- instance T.MonadIO m => T.MonadIO (RVarT m) where
---     liftIO = T.lift . T.liftIO
+instance T.MonadIO m => T.MonadIO (RVarT m) where
+    liftIO = T.lift . T.liftIO
 
 data RGen = RGen
 

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -208,7 +208,7 @@ runPromptT' prm lft e = foldF alg e
 
 {-# INLINE uniformPrimM #-}
 uniformPrimM :: StatefulGen g m => Prim t -> g -> m t
-uniformPrimM (Prim f) g = uniformDoublePositive01M g >>= return . f
+uniformPrimM (Prim f) g = uniformWord32 g >>= return . f
 
 -- |@sampleRVarTWith lift x@ is equivalent to @runRVarTWith lift x 'StdRandom'@.
 {-# INLINE sampleReaderRVarTWith #-}
@@ -251,9 +251,7 @@ instance T.MonadIO m => T.MonadIO (RVarT m) where
 data RGen = RGen
 
 instance Functor m => StatefulGen RGen (RVarT m) where
-    uniformWord32 RGen            = liftF (Prim f)
-      where
-        f x = floor $ x * fromIntegral (maxBound :: Word32)
+    uniformWord32 RGen             = liftF (Prim id)
     {-# INLINE uniformWord32 #-}
     uniformShortByteString _n RGen = RVarT $ error "ShortByteString"
     {-# INLINE uniformShortByteString #-}

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -38,7 +38,6 @@ module Data.RVar
 
 
 import qualified Control.Monad.IO.Class as T
-import Control.Monad.Prompt (MonadPrompt(..), PromptT, runPromptT)
 import Control.Monad.Reader as MTL
 import Control.Monad.State as MTL
 import qualified Control.Monad.Trans.Class as T

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -30,8 +30,8 @@ module Data.RVar
     -- , sampleStateRVarTWith
 
     , RGen(..)
-    -- , uniformRVarT
-    -- , uniformRangeRVarT
+    , uniformRVarT
+    , uniformRangeRVarT
 
     , Prim(..)
     ) where

--- a/rvar/src/Data/RVar/Prim.hs
+++ b/rvar/src/Data/RVar/Prim.hs
@@ -35,3 +35,6 @@ instance Show (Prim a) where
     showsPrec _p PrimWord64        = showString "PrimWord64"
     showsPrec  p (PrimShortByteString n) =
       showParen (p > 10) (showString "PrimShortByteString " . showsPrec 11 n)
+
+instance Functor Prim where
+  fmap _ _ = error "Functor Prim"

--- a/rvar/src/Data/RVar/Prim.hs
+++ b/rvar/src/Data/RVar/Prim.hs
@@ -6,11 +6,13 @@
 -- uniform and efficient way, as functions of type @Prim a -> m a@.
 module Data.RVar.Prim (Prim(..)) where
 
+import Data.Word
+
 -- |A type describing a request for a primitive random variate. This
 -- data type is needed for creating
 -- `System.Random.Stateful.StatefulGen` instance for `Data.RVar.RVarT`
 
-data Prim a = Prim (Double -> a)
+data Prim a = Prim (Word32 -> a)
 
 instance Functor Prim where
   fmap f (Prim k) = Prim (f . k)

--- a/rvar/src/Data/RVar/Prim.hs
+++ b/rvar/src/Data/RVar/Prim.hs
@@ -6,38 +6,9 @@
 -- uniform and efficient way, as functions of type @Prim a -> m a@.
 module Data.RVar.Prim (Prim(..)) where
 
-import Data.Typeable
-import Data.Word
-import Data.ByteString.Short
-
--- |A 'Prompt' GADT describing a request for a primitive random variate.  Random variable
--- definitions will request their entropy via these prompts, and entropy sources will
--- satisfy those requests. This data type is needed for creating
+-- |A type describing a request for a primitive random variate. This
+-- data type is needed for creating
 -- `System.Random.Stateful.StatefulGen` instance for `Data.RVar.RVarT`
---
--- data Prim a where
---     -- | An unsigned byte, uniformly distributed from 0 to 0xff
---     PrimWord8           :: Prim Word8
---     -- | An unsigned 16-bit word, uniformly distributed from 0 to 0xffff
---     PrimWord16          :: Prim Word16
---     -- | An unsigned 32-bit word, uniformly distributed from 0 to 0xffffffff
---     PrimWord32          :: Prim Word32
---     -- | An unsigned 64-bit word, uniformly distributed from 0 to 0xffffffffffffffff
---     PrimWord64          :: Prim Word64
---     -- | A uniformly distributed `ShortByteString` of length @n@ bytes
---     PrimShortByteString :: !Int -> Prim ShortByteString
---     deriving (Typeable)
-
--- instance Show (Prim a) where
---     showsPrec _p PrimWord8         = showString "PrimWord8"
---     showsPrec _p PrimWord16        = showString "PrimWord16"
---     showsPrec _p PrimWord32        = showString "PrimWord32"
---     showsPrec _p PrimWord64        = showString "PrimWord64"
---     showsPrec  p (PrimShortByteString n) =
---       showParen (p > 10) (showString "PrimShortByteString " . showsPrec 11 n)
-
--- instance Functor Prim where
---   fmap _ _ = error "Functor Prim"
 
 data Prim a = Prim (Double -> a)
 

--- a/rvar/src/Data/RVar/Prim.hs
+++ b/rvar/src/Data/RVar/Prim.hs
@@ -15,26 +15,31 @@ import Data.ByteString.Short
 -- satisfy those requests. This data type is needed for creating
 -- `System.Random.Stateful.StatefulGen` instance for `Data.RVar.RVarT`
 --
-data Prim a where
-    -- | An unsigned byte, uniformly distributed from 0 to 0xff
-    PrimWord8           :: Prim Word8
-    -- | An unsigned 16-bit word, uniformly distributed from 0 to 0xffff
-    PrimWord16          :: Prim Word16
-    -- | An unsigned 32-bit word, uniformly distributed from 0 to 0xffffffff
-    PrimWord32          :: Prim Word32
-    -- | An unsigned 64-bit word, uniformly distributed from 0 to 0xffffffffffffffff
-    PrimWord64          :: Prim Word64
-    -- | A uniformly distributed `ShortByteString` of length @n@ bytes
-    PrimShortByteString :: !Int -> Prim ShortByteString
-    deriving (Typeable)
+-- data Prim a where
+--     -- | An unsigned byte, uniformly distributed from 0 to 0xff
+--     PrimWord8           :: Prim Word8
+--     -- | An unsigned 16-bit word, uniformly distributed from 0 to 0xffff
+--     PrimWord16          :: Prim Word16
+--     -- | An unsigned 32-bit word, uniformly distributed from 0 to 0xffffffff
+--     PrimWord32          :: Prim Word32
+--     -- | An unsigned 64-bit word, uniformly distributed from 0 to 0xffffffffffffffff
+--     PrimWord64          :: Prim Word64
+--     -- | A uniformly distributed `ShortByteString` of length @n@ bytes
+--     PrimShortByteString :: !Int -> Prim ShortByteString
+--     deriving (Typeable)
 
-instance Show (Prim a) where
-    showsPrec _p PrimWord8         = showString "PrimWord8"
-    showsPrec _p PrimWord16        = showString "PrimWord16"
-    showsPrec _p PrimWord32        = showString "PrimWord32"
-    showsPrec _p PrimWord64        = showString "PrimWord64"
-    showsPrec  p (PrimShortByteString n) =
-      showParen (p > 10) (showString "PrimShortByteString " . showsPrec 11 n)
+-- instance Show (Prim a) where
+--     showsPrec _p PrimWord8         = showString "PrimWord8"
+--     showsPrec _p PrimWord16        = showString "PrimWord16"
+--     showsPrec _p PrimWord32        = showString "PrimWord32"
+--     showsPrec _p PrimWord64        = showString "PrimWord64"
+--     showsPrec  p (PrimShortByteString n) =
+--       showParen (p > 10) (showString "PrimShortByteString " . showsPrec 11 n)
+
+-- instance Functor Prim where
+--   fmap _ _ = error "Functor Prim"
+
+data Prim a = Prim (Double -> a)
 
 instance Functor Prim where
-  fmap _ _ = error "Functor Prim"
+  fmap f (Prim k) = Prim (f . k)


### PR DESCRIPTION
I think using free monads helps understand that really PromptT is a sum type not a transformer (as the suffix T would suggest). In particular, I think this is clearer than the original

```
newtype RVarT m a = RVarT { unRVarT :: F (Sum Prim m) a }

type f :-> g = forall i. f i -> g i

runRVarTWith :: forall m n g a . StatefulGen g m =>
           (n :-> m) -> RVarT n a -> g -> m a
runRVarTWith liftN (RVarT m) gen = runPromptT' (\p -> uniformPrimM p gen) liftN m

runPromptT' :: forall m n p r . (Monad n) => (p :-> n) -> (m :-> n) -> F (Sum p m) r -> n r
runPromptT' prm lft e = foldF alg e
  where
    alg :: Sum p m i -> n i
    alg (InL x) = prm x
    alg (InR y) = lft y
```

I haven't figurred everything out though - I don't know how to make `Prim` a functor (you can only create a free monad from a functor).